### PR TITLE
use exclusive sockets in cluster mode

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,7 +72,7 @@ UDPSocket.prototype.bind = function(type) {
       self.emit('close');
     });
 
-    this._socket.bind();
+    this._socket.bind({ exclusive: true });
   }
 };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,38 @@
+var childProcess = require('child_process');
+
+exports.exclusiveSocketsInClusterMode = function (test) {
+
+  function clusterModeTest() {
+    var cluster = require('cluster');
+    var utils = require('./lib/utils');
+
+    if (cluster.isMaster) {
+      var workerSocketsPorts = [];
+
+      cluster.on('message', function (worker, message) {
+        if (message.port) {
+          workerSocketsPorts.push(message.port);
+          if (workerSocketsPorts.length === 2) {
+            process.exit(workerSocketsPorts[0] === workerSocketsPorts[1] ? -1 : 0);
+          }
+        }
+      });
+
+      cluster.fork();
+      cluster.fork();
+    } else {
+      var udpSocket = new utils.UDPSocket();
+
+      udpSocket
+        .on('ready', function () { process.send({ port: udpSocket._socket.address().port }); })
+        .bind('udp4');
+    }
+  }
+
+  var inlineScript = ('"(' + clusterModeTest.toString().replace(/\n/g, '') + ').call();"');
+
+  childProcess.exec('node -e ' + inlineScript, function (err) {
+    test.ifError(err, 'Should not share the same socket port');
+    test.done();
+  });
+};


### PR DESCRIPTION
native-dns is unusable in cluster mode, because of the way the cluster mode affects binding to a random port (as described in: https://nodejs.org/api/cluster.html#cluster_how_it_works): 
- all the workers will share the same port and as a result of this, responses will be load balanced according to cluster mode policy
- in our case we don't want that, we want to have unique sockets

the solution is to disable port sharing when creating a socket, as described in:
- https://nodejs.org/api/dgram.html#dgram_socket_bind_options_callback